### PR TITLE
Switch to BaseSettings for config

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,22 +1,22 @@
-import os
-from dotenv import load_dotenv
-from pydantic import BaseModel
-# Загружаем переменные окружения из файла .env
+"""Application settings loaded from environment variables."""
 
-load_dotenv()
+from pydantic_settings import BaseSettings
 
 
-class Settings(BaseModel):
-    VLLM_MODEL: str = os.getenv("VLLM_MODEL", "/home/nikita/PROJECTS/vllm5090/project/vikhr/models/QVikhr-3-1.7B")
-    HOST: str = os.getenv("HOST", "0.0.0.0")
-    PORT: int = int(os.getenv("PORT", "8000"))
-    DEBUG: bool = os.getenv("DEBUG", "false").lower() == "true"  # Конвертируем строку в булево значение
-    LOG_LEVEL: str = os.getenv("LOG_LEVEL", "info")
-    API_PREFIX: str = os.getenv("API_PREFIX", "v1")
-    MAX_TOKENS: int = int(os.getenv("MAX_TOKENS", "8192"))  
-    TEMPERATURE: float = float(os.getenv("TEMPERATURE", "0.2")) 
-    STREAM: bool = os.getenv("STREAM", "false").lower() == "true"  # Конвертируем строку в булево значение
-    GPU_MEMORY_UTILIZATION: float = float(os.getenv("GPU_MEMORY_UTILIZATION", "0.5"))  
-    TENSOR_PARALLEL_SIZE: int = int(os.getenv("TENSOR_PARALLEL_SIZE", "1"))  
+class Settings(BaseSettings):
+    VLLM_MODEL: str = "/home/nikita/PROJECTS/vllm5090/project/vikhr/models/QVikhr-3-1.7B"
+    HOST: str = "0.0.0.0"
+    PORT: int = 8000
+    DEBUG: bool = False
+    LOG_LEVEL: str = "info"
+    API_PREFIX: str = "v1"
+    MAX_TOKENS: int = 8192
+    TEMPERATURE: float = 0.2
+    STREAM: bool = False
+    GPU_MEMORY_UTILIZATION: float = 0.5
+    TENSOR_PARALLEL_SIZE: int = 1
+
+    class Config:
+        env_file = ".env"
 
 settings = Settings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 fastapi[standard]
+pydantic-settings


### PR DESCRIPTION
## Summary
- use `BaseSettings` via `pydantic-settings`
- load `.env` automatically with `Config.env_file`
- add missing dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684095b8565483208f96a55c187775fb